### PR TITLE
Link custom sce project directories

### DIFF
--- a/sce.py
+++ b/sce.py
@@ -5,6 +5,7 @@ from tools.setup import SceSetupTool
 from tools.sce_service_handler import SceServiceHandler
 from tools.sce_presubmit_handler import ScePresubmitHandler
 
+sce_dir = os.getcwd()
 parser = argparse.ArgumentParser()
 sub_parser = parser.add_subparsers(required=True, dest='command')
 
@@ -26,13 +27,27 @@ presubmit_parser.add_argument(
     help='Project to run presubmit checks for.'
 )
 
+def directory(path):
+    if os.path.isdir(path):
+        return path
+    else:
+        raise ValueError(f'{path}: No such directory')
+
+linker_parser = sub_parser.add_parser('link', help='Link existing sce project clones')
+linker_parser.add_argument(
+    'path', help='Path to project clone', type=directory
+)
+linker_parser.add_argument(
+    'project', help='Name of project to link against'
+)
+
 args = parser.parse_args()
 
 # cd into the dev folder if we are in windows.
 # we dont need to do it for unix/macos because
 # changing the directory is part of the sce alias.
 if args.command == 'setup':
-    setup = SceSetupTool()
+    setup = SceSetupTool(sce_dir)
     setup.setup()
 else:
     if platform.system() == 'Windows':
@@ -44,4 +59,5 @@ else:
     elif args.command == 'run':
         handler = SceServiceHandler(args.service, args.dbpath)
         handler.run_services()
-
+    elif args.command == 'link':
+        os.symlink(os.path.abspath(args.path), os.path.join(sce_dir, args.project))

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -46,7 +46,7 @@ class SceSetupTool:
                 ' to the sce cli?(y or n): ', lambda ans: ans == 'y' or ans == 'n')
         if custom_dir == 'y':
             user_project_dir = prompt_user(f'enter a valid path of {name}: ',
-                    lambda path: os.path.isdir(path) and os.path.isabs(path))
+                    lambda path: os.path.isdir(path))
 
             os.symlink(user_project_dir, os.path.join(self.sce_path, name),
                     target_is_directory=True)

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -40,6 +40,18 @@ class SceSetupTool:
             print("visit here to install: ")
             self.color.print_purple(link)
             input("press enter to continue: ")
+
+    def link(self, name):
+        custom_dir = prompt_user(f'would you like to link an existing clone of {name}'
+                ' to the sce cli?(y or n): ', lambda ans: ans == 'y' or ans == 'n')
+        if custom_dir == 'y':
+            user_project_dir = prompt_user(f'enter a valid, absolute path of {name}: ',
+                    lambda path: os.path.isdir(path) and os.path.isabs(path))
+
+            os.symlink(user_project_dir, os.path.join(self.sce_path, name),
+                    target_is_directory=True)
+            return True
+        return False
     
     def check_directory(self, name):
         """
@@ -52,17 +64,8 @@ class SceSetupTool:
         if os.path.isdir(name):
             self.color.print_pink(name + " directory found")
         else:
-            self.color.print_red(
-                name + ' directory not found')
-            custom_dir = prompt_user(f'would you like to link an existing clone of {name}'
-                    ' to the sce cli?(y or n): ', lambda ans: ans == 'y' or ans == 'n')
-            if custom_dir == 'y':
-                user_project_dir = prompt_user(f'enter a valid, absolute path of {name}: ',
-                        lambda path: os.path.isdir(path) and os.path.isabs(path))
-
-                os.symlink(user_project_dir, os.path.join(self.sce_path, name),
-                        target_is_directory=True)
-            else:
+            self.color.print_red(name + ' directory not found')
+            if not self.link(name):
                 subprocess.check_call("git clone "
                                       + "https://github.com/SCE-Development/"
                                       + name, stderr=subprocess.STDOUT, shell=True)

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -14,10 +14,11 @@ class SceSetupTool:
     color = Colors()
     devnull = open(os.devnull, 'wb')
     docker_is_running = True
-    sce_path = os.getcwd()
+    sce_path = "" # passed in through __init__
 
-    def __init__(self):
+    def __init__(self, sce_path):
         self.operating = platform.system()
+        self.sce_path = sce_path
 
     def check_installation(self, name, command, link):
         """
@@ -187,7 +188,8 @@ class SceSetupTool:
             f'{command} -m pip install -r ./requirements.txt --user',
             stderr=subprocess.STDOUT, shell=True)
 
-    def setup(self):
+    def setup(self, sce_dir):
+        self.sce_dir = sce_dir
         self.color.print_purple(f'Detected OS: {self.operating}')
 
         self.check_docker()

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -45,7 +45,7 @@ class SceSetupTool:
         custom_dir = prompt_user(f'would you like to link an existing clone of {name}'
                 ' to the sce cli?(y or n): ', lambda ans: ans == 'y' or ans == 'n')
         if custom_dir == 'y':
-            user_project_dir = prompt_user(f'enter a valid, absolute path of {name}: ',
+            user_project_dir = prompt_user(f'enter a valid path of {name}: ',
                     lambda path: os.path.isdir(path) and os.path.isabs(path))
 
             os.symlink(user_project_dir, os.path.join(self.sce_path, name),

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -47,7 +47,7 @@ class SceSetupTool:
         if custom_dir == 'y':
             user_project_dir = prompt_user(f'enter a valid path of {name}: ',
                     lambda path: os.path.isdir(path))
-
+            user_project_dir = os.path.abspath(user_project_dir)
             os.symlink(user_project_dir, os.path.join(self.sce_path, name),
                     target_is_directory=True)
             return True

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -185,8 +185,6 @@ class SceSetupTool:
             stderr=subprocess.STDOUT, shell=True)
 
     def setup(self):
-        os.chdir(self.sce_path)
-
         self.color.print_purple(f'Detected OS: {self.operating}')
 
         self.check_docker()

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -188,8 +188,7 @@ class SceSetupTool:
             f'{command} -m pip install -r ./requirements.txt --user',
             stderr=subprocess.STDOUT, shell=True)
 
-    def setup(self, sce_dir):
-        self.sce_dir = sce_dir
+    def setup(self):
         self.color.print_purple(f'Detected OS: {self.operating}')
 
         self.check_docker()

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -35,3 +35,17 @@ def check_docker_status():
       'is_installed': True,
       'is_running': False
     }
+
+def ask_user(prompt, validator):
+"""
+this method continually prompts the user to enter a "valid" input. 
+validator should be a one argument function which returns a Boolean 
+(whether the input is valid or invalid)
+Returns:
+    the valid user input
+"""
+    ans = input(prompt)
+    while not validator(ans):
+        ans = input(prompt)
+    return ans
+

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -36,7 +36,6 @@ def check_docker_status():
       'is_running': False
     }
 
-def ask_user(prompt, validator):
 """
 this method continually prompts the user to enter a "valid" input. 
 validator should be a one argument function which returns a Boolean 
@@ -44,6 +43,7 @@ validator should be a one argument function which returns a Boolean
 Returns:
     the valid user input
 """
+def prompt_user(prompt, validator):
     ans = input(prompt)
     while not validator(ans):
         ans = input(prompt)


### PR DESCRIPTION
Resolves #24.

Added `sce_path` to `SceSetupTool`. This is where the tool looks for SCE projects. Later on we can set it to a hidden home directory in unix and `AppData` in windows. 

When looking for a project and it isn't found (in `sce_path`), this pr allows the user to give a path to an existing clone of the project. Then, it makes a symbolic link from that clone to `sce_path` (from `SceSetupTool`). If the user doesn't want to link an existing clone, it'll clone it to `sce_path`. 

And also `prompt_user(prompt, validator)` in utils to create user prompts more easily. 