### PR TITLE
gitgnore project repo symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,10 @@
 # to ignore generated symlinks
 Core-v4
 SCE-discord-bot
-discord-bot
 Quasar
 
 Core-v4/
 SCE-discord-bot/
-discord-bot/
 Quasar/
 
 *.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 Core-v4
 SCE-discord-bot
 discord-bot
-quasar
+Quasar
 
 Core-v4/
 SCE-discord-bot/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,13 @@
+Core-v4
+SCE-discord-bot
+discord-bot
+quasar
+
 Core-v4/
 SCE-discord-bot/
+discord-bot/
+quasar/
+
 *.pyc
 .idea/
 build/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+# to ignore generated symlinks
 Core-v4
 SCE-discord-bot
 discord-bot
@@ -6,7 +7,7 @@ Quasar
 Core-v4/
 SCE-discord-bot/
 discord-bot/
-quasar/
+Quasar/
 
 *.pyc
 .idea/


### PR DESCRIPTION
#41 symlinks projects to `sce_path`. Symlinks are files so the current gitignore doesn't ignore it. 

before:
![](https://user-images.githubusercontent.com/36345325/158852466-a80d3569-7422-492b-a2cb-00c93aa223b8.png)
