### PR TITLE
prevent duplicate email creation using sce create

### DIFF
--- a/sce.bat
+++ b/sce.bat
@@ -178,6 +178,14 @@ REM set the varible %name% to the resolved repo.
         goto :exit_error
     )
 
+    SET "chars=ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+    SET "random_suffix="
+    FOR /L %%i IN (1,1,4) DO (
+        SET /A "idx=!RANDOM! %% 62"
+        FOR %%j IN (!idx!) DO SET "random_suffix=!random_suffix!!chars:~%%j,1!"
+    )
+    SET "generated_email=test_!random_suffix!@one.sce"
+
     (
         echo use sce_core
         echo db.User.insertOne({
@@ -187,11 +195,11 @@ REM set the varible %name% to the resolved repo.
         echo     password: '$2a$10$HWbBiWRso1IUgqnuV6t1hO6lCBWO7KTC/E3G1MsFoXKH7/l/4FVK2',
         echo     firstName: 'Development',
         echo     lastName: 'Account',
-        echo     email: 'test@one.sce',
+        echo     email: '!generated_email!',
         echo })
     ) | docker exec -i sce-mongodb-dev mongosh --quiet --norc --shell
     echo created %access_level_name% user for the SCE website with:
-    echo email:    test@one.sce
+    echo email:    !generated_email!
     echo password: sce
     goto :exit_success
 

--- a/sce.sh
+++ b/sce.sh
@@ -161,6 +161,9 @@ then
             ;;
     esac
 
+    random_suffix=$(cat /dev/urandom | LC_ALL=C tr -dc 'a-zA-Z0-9' | head -c 4)
+    generated_email="test_${random_suffix}@one.sce"
+
     mongo_script="use sce_core
         db.User.insertOne({
             emailVerified: true,
@@ -169,12 +172,12 @@ then
             password: '\$2a\$10\$HWbBiWRso1IUgqnuV6t1hO6lCBWO7KTC/E3G1MsFoXKH7/l/4FVK2',
             firstName: 'Development',
             lastName: 'Account',
-            email: 'test@one.sce',
+            email: '$generated_email',
         })"
 
     echo "$mongo_script" | docker exec -i sce-mongodb-dev mongosh --shell --norc --quiet
     echo "created $access_level_name user for the SCE website with:"
-    echo "email:    test@one.sce"
+    echo "email:    $generated_email"
     echo "password: sce"
     exit 0
 fi


### PR DESCRIPTION
previously when running `sce create`, the test account would always be `test@one.sce`. but if you want to create multiple accounts, this would cause a MongoDB duplicate key error. so now we add a randomized alphanumeric string of length 4 to the end of the email, so it's now `test_XXXX@one.sce` where XXXX is the aforementioned string.