### PR TITLE
Fix `sce update` failure on Windows

### DIFF
--- a/go/install.ps1
+++ b/go/install.ps1
@@ -2,6 +2,9 @@ $ErrorActionPreference = "Stop"
 
 $repo = "SCE-Development/SCE-CLI"
 $installDir = "$env:LOCALAPPDATA\sce"
+$target = Join-Path $installDir "sce.exe"
+$staged = Join-Path $installDir "sce.exe.new"
+$helper = Join-Path $env:TEMP "sce-update-$PID.ps1"
 
 # Detect architecture
 $arch = if ([Environment]::Is64BitOperatingSystem) { "amd64" } else { "amd64" }
@@ -12,7 +15,48 @@ $url = "https://github.com/$repo/releases/latest/download/$binary"
 
 Write-Host "downloading sce for windows/$arch..."
 New-Item -ItemType Directory -Path $installDir -Force | Out-Null
-Invoke-WebRequest -Uri $url -OutFile "$installDir\sce.exe" -UseBasicParsing
+Remove-Item -Path $staged -Force -ErrorAction SilentlyContinue
+Invoke-WebRequest -Uri $url -OutFile $staged -UseBasicParsing
+
+$replaceScript = @"
+param(
+    [string]
+    `$Target,
+    [string]
+    `$Source
+)
+
+while (`$true) {
+    try {
+        if (-not (Test-Path -Path `$Target)) {
+            break
+        }
+
+        `$stream = [System.IO.File]::Open(`$Target, 'Open', 'ReadWrite', 'None')
+        `$stream.Close()
+        break
+    } catch {
+        Start-Sleep -Milliseconds 250
+    }
+}
+
+Move-Item -Force -Path `$Source -Destination `$Target
+"@
+
+Set-Content -Path $helper -Value $replaceScript -Encoding UTF8
+Start-Process powershell -WindowStyle Hidden -ArgumentList @(
+    "-NoProfile",
+    "-ExecutionPolicy",
+    "Bypass",
+    "-File",
+    $helper,
+    "-Target",
+    $target,
+    "-Source",
+    $staged
+) | Out-Null
+
+Write-Host "update downloaded; applying it after this command exits..."
 
 # Add to PATH if not already there
 $userPath = [Environment]::GetEnvironmentVariable("Path", "User")


### PR DESCRIPTION
## Problem
PowerShell attempted to overwrite the current `sce.exe` executable during the execution of `sce update`, which resulted in the error "The process cannot access the file `C:\...\sce.exe` because it is being used by another process".

## The Fix
Now, the update is scheduled to execute after `sce update` exits, so the current `sce.exe` is not overwritten mid-process.

## Testing
This has been tested using GitHub Actions workflows, and confirmed to pass. Those workflows were rolled back once behavior was validated.