### PR TITLE
Add command to check CLI version 

### DIFF
--- a/go/cmd/root.go
+++ b/go/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/SCE-Development/SCE-CLI/internal"
 	"github.com/spf13/cobra"
@@ -31,11 +32,14 @@ var rootCmd = &cobra.Command{
 		if skipVersionCheck[cmd.Name()] {
 			return
 		}
-		latest := internal.LatestRelease()
-		if latest == "" || latest == currentVersion {
+		// release tags are prefixed with a v (v0.5) but goreleaser strips it
+		// from the injected version (0.5), so compare without the prefix.
+		latest := strings.TrimPrefix(internal.LatestRelease(), "v")
+		current := strings.TrimPrefix(currentVersion, "v")
+		if latest == "" || latest == current {
 			return
 		}
-		fmt.Fprintf(os.Stderr, "your cli is outdated (%s → %s). run `sce update` to get the latest version\n\n", currentVersion, latest)
+		fmt.Fprintf(os.Stderr, "your cli is outdated (%s → %s). run `sce update` to get the latest version\n\n", current, latest)
 	},
 }
 

--- a/go/cmd/version.go
+++ b/go/cmd/version.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Show the version of the SCE CLI",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(currentVersion)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}


### PR DESCRIPTION
Run `sce version` to check the current version of your CLI.

Also: fixed a bug where the string comparison of the downloaded CLI version to the latest CLI version available from GitHub Releases was incorrectly parsing the tags, leading to the CLI telling the user that the CLI version was outdated on every command regardless of the version comparison.